### PR TITLE
Feature/ta bv 389

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -98,9 +98,9 @@ export default class App extends React.Component<Props, any> {
                             <Route path='/session/:session' component={Session} />
                             <Route path='/endpoint/:channel' component={Endpoint} />
                             <Route path='/setAccount' render={() => <SetAccount default={false} />} />
-                            <Route path='/generateKey/:default' component={GenerateKey} />
-                            <Route path='/importHexKey' component={ImportHexKey} />
-                            <Route path='/importJsonKey' component={ImportJsonKey} />
+                            <Route path='/generateKey/:default' render={ (props:any) => <GenerateKey default={props.match.params.default} /> } />
+                            <Route path='/importHexKey/:default' render={ (props:any) => <ImportHexKey default={props.match.params.default} /> } />
+                            <Route path='/importJsonKey/:default' component={ (props:any) => <ImportJsonKey default={props.match.params.default} /> } />
                             <Route path='/backup/:privateKey/:from' render={ (props:any) => <Backup entryPoint={'/accounts'} privateKey={props.match.params.privateKey} from={props.match.params.from}/> } />
                             <Route path='/logs' component={Logs} />
 

--- a/src/components/auth/generateKey.tsx
+++ b/src/components/auth/generateKey.tsx
@@ -37,7 +37,7 @@ class GenerateKey extends React.Component<any, any>{
         const dk = createPrivateKey();
         const key = dk.privateKey.toString('base64').split('+').join('-').split('/').join('_');
         const body = {privateKey: key
-                     ,isDefault: this.props.match.params.default === 'true'
+                     ,isDefault: this.props.default === 'true'
                      ,inUse: true
                      ,name
                      ,type: 'generate_new'

--- a/src/components/auth/importHexKey.tsx
+++ b/src/components/auth/importHexKey.tsx
@@ -45,12 +45,17 @@ class ImportHexKey extends React.Component<any, any>{
         const pk = new Buffer(privateKey, 'hex');
         const key = pk.toString('base64').split('+').join('-').split('/').join('_');
         const body = {privateKey: key
-                     ,isDefault: this.props.match.params.default === 'true'
+                     ,isDefault: this.props.default === 'true'
                      ,inUse: true
                      ,name
                      ,type: 'generate_new'
         };
         const res = await fetch('/accounts/', {method: 'post', body});
+
+        const settings = await fetch('/localSettings', {}) as any;
+        settings.accountCreated = true;
+        await fetch('/localSettings', {method: 'put', body: settings});
+
         const dk = createPrivateKey();
         console.log(res, dk);
         const newKeyObject = Object.assign({}, dk, {privateKey: pk});

--- a/src/components/auth/importJsonKey.tsx
+++ b/src/components/auth/importJsonKey.tsx
@@ -56,13 +56,18 @@ class ImportJsonKey extends React.Component<any, any>{
         console.log(pk, key);
 
         const body = {privateKey: key
-                     ,isDefault: this.props.match.params.default === 'true'
+                     ,isDefault: this.props.default === 'true'
                      ,inUse: true
                      ,name
                      ,type: 'generate_new'
         };
         console.log(body);
         await fetch('/accounts/', {method: 'post', body});
+
+        const settings = await fetch('/localSettings', {}) as any;
+        settings.accountCreated = true;
+        await fetch('/localSettings', {method: 'put', body: settings});
+
         const dk = createPrivateKey();
         const newKeyObject = Object.assign({}, dk, {privateKey: pk});
         this.props.history.push(`/backup/${JSON.stringify(newKeyObject)}/importJsonKey`);

--- a/src/components/start.tsx
+++ b/src/components/start.tsx
@@ -28,9 +28,9 @@ const wizard = <Router history={MemoryHistory as any}>
     <Switch>
         <Route exact path='/' component={SetPassword} />
         <Route path='/setAccount' render={() => <SetAccount default={true} /> } />
-        <Route path='/generateKey/:default' component={GenerateKey} />
-        <Route path='/importHexKey' component={ImportHexKey} />
-        <Route path='/importJsonKey' component={ImportJsonKey} />
+        <Route path='/generateKey/:default' render={ (props:any) => <GenerateKey default={props.match.params.default} /> } />
+        <Route path='/importHexKey/:default' render={ (props:any) => <ImportHexKey default={props.match.params.default} /> } />
+        <Route path='/importJsonKey/:default' component={ (props:any) => <ImportJsonKey default={props.match.params.default} /> } />
         <Route path='/backup/:privateKey/:from' render={(props: any) => <Backup entryPoint={'/app'} privateKey={props.match.params.privateKey} from={props.match.params.from}/>} />
         <Route path='/login' component={Login} />
         <Route path='/app' component={App} />
@@ -41,9 +41,9 @@ const setAccount = <Router history={MemoryHistory as any}>
     <Switch>
         <Route exact path='/' render={() => <Login entryPoint={'/setAccount'} />} />
         <Route path='/setAccount' render={() => <SetAccount default={true} /> } />
-        <Route path='/generateKey/:default' component={GenerateKey} />
-        <Route path='/importHexKey' component={ImportHexKey} />
-        <Route path='/importJsonKey' component={ImportJsonKey} />
+        <Route path='/generateKey/:default' render={ (props:any) => <GenerateKey default={props.match.params.default} /> } />
+        <Route path='/importHexKey/:default' render={ (props:any) => <ImportHexKey default={props.match.params.default} /> } />
+        <Route path='/importJsonKey/:default' component={ (props:any) => <ImportJsonKey default={props.match.params.default} /> } />
         <Route path='/backup/:privateKey/:from' render={ (props:any) => <Backup entryPoint={'/app'} privateKey={props.match.params.privateKey} from={props.match.params.from}/> } />
         <Route path='/app' component={App} />
     </Switch>


### PR DESCRIPTION
Original report:
Clean setup of develop.
In first setup wizard I've chosen "Import from JSON".
In settings.json I've seen, after wizard:
First setup = false
account created = false
In DB (DB.products) I see server object (as usual).In new offering view - empty drop down.

---

Must be: list of products (if any in db) no matter how exactly account was imported (generated, hex/json import)
Another way to check - `is default`  status of account, must be `on` for first account imported while setting up application.